### PR TITLE
Specify signals for status register under all conditions

### DIFF
--- a/vhdl/interface/Speck_AXI_v2_0.vhd
+++ b/vhdl/interface/Speck_AXI_v2_0.vhd
@@ -289,6 +289,7 @@ Speck_AXI_v2_0_S00_AXI_inst : Speck_AXI_v2_0_S00_AXI
                 end if;
                 cipher_stat_register_0(1) <= '1';
             else
+                cipher_stat_register_0(0) <= cipher_stat_register_0(0);
                 cipher_stat_register_0(1) <= cipher_stat_register_0(1);
             end if;
         end if;


### PR DESCRIPTION
There is no need to store the bit for the else case. Make it explicit that the value stays the same.